### PR TITLE
feat: Persistent disk, Docker details post, EnvVars in ServicePOST and Image in ServicePOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,29 @@ resource "render_service" "nextjs" {
   }
 }
 
+
+resource "render_service" "python_app" {
+  name   = "my_python_app"
+  repo   = "https://github.com/render-examples/flask-hello-world"
+  type   = "web_service"
+  branch = "master"
+
+  web_service_details = {
+    env    = "python"
+    region = "frankfurt"
+    plan   = "starter"
+    native = {
+      build_command = "pip install -r requirements.txt"
+      start_command = "gunicorn app:app"
+    }
+    disk = {
+      name = "my_app_data"
+      mount_path = "/my_app_data"
+      size_gb = 10
+    }
+  }
+}
+
 resource "render_service" "mongodb" {
   name = "mongodb"
   repo = "https://github.com/render-examples/mongodb"

--- a/examples/deploy-flask/main.tf
+++ b/examples/deploy-flask/main.tf
@@ -19,7 +19,7 @@ resource "render_service" "flask" {
   branch = "master"
 
   web_service_details = {
-    env    = "node"
+    env    = "python"
     region = "frankfurt"
     plan   = "starter"
     native = {

--- a/render/models/service.go
+++ b/render/models/service.go
@@ -28,6 +28,7 @@ type WebServiceDetails struct {
 	HealthCheckPath            types.String             `tfsdk:"health_check_path"`
 	Native                     *WebServiceDetailsNative `tfsdk:"native"`
 	Url                        types.String             `tfsdk:"url"`
+	Disk                       *Disk                    `tfsdk:"disk"`
 }
 
 type WebServiceDetailsNative struct {

--- a/render/models/service.go
+++ b/render/models/service.go
@@ -89,6 +89,15 @@ func (s Service) FromResponse(response render.Service) Service {
 				StartCommand: fromStringOptional(native.StartCommand),
 			}
 		}
+		if details.Disk != nil {
+			service.WebServiceDetails.Disk = &Disk{
+				Name: fromStringOptional(details.Disk.Name),
+
+				// Hack because the OpenAPI doesn't specify these fields as return.. I should check this
+				MountPath: s.WebServiceDetails.Disk.MountPath,
+				SizeGB:    s.WebServiceDetails.Disk.SizeGB,
+			}
+		}
 	}
 
 	if serviceType == render.PrivateService {
@@ -323,6 +332,10 @@ func toWebServiceDetails(webServiceDetails *WebServiceDetails) (map[string]inter
 		}
 
 		details["envSpecificDetails"] = native
+	}
+
+	if webServiceDetails.Disk != nil {
+		details["disk"] = toDisk(webServiceDetails.Disk)
 	}
 
 	return details, nil

--- a/render/resources/service.go
+++ b/render/resources/service.go
@@ -96,6 +96,7 @@ func (r *serviceResource) Schema(_ context.Context, req resource.SchemaRequest, 
 							"start_command": schema.StringAttribute{Optional: true},
 						},
 					},
+					"disk": disk,
 				},
 			},
 

--- a/render/resources/service.go
+++ b/render/resources/service.go
@@ -67,6 +67,15 @@ func (r *serviceResource) Schema(_ context.Context, req resource.SchemaRequest, 
 		},
 	}
 
+	docker := schema.SingleNestedAttribute{
+		Optional: true,
+		Attributes: map[string]schema.Attribute{
+			"command": schema.StringAttribute{Optional: true},
+			"context": schema.StringAttribute{Optional: true},
+			"path":    schema.StringAttribute{Optional: true},
+		},
+	}
+
 	resp.Schema = schema.Schema{
 		Description: `Provider for service resource`,
 		Attributes: map[string]schema.Attribute{
@@ -75,8 +84,28 @@ func (r *serviceResource) Schema(_ context.Context, req resource.SchemaRequest, 
 			"type":        schema.StringAttribute{Required: true, PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
 			"branch":      schema.StringAttribute{Optional: true, Computed: true},
 			"auto_deploy": schema.BoolAttribute{Optional: true},
-			"repo":        schema.StringAttribute{Required: true, PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
+			"repo":        schema.StringAttribute{Optional: true, PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
 			"owner":       schema.StringAttribute{Optional: true, Computed: true, PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}},
+			"env_vars": schema.ListNestedAttribute{
+				Description: "Service environment variable",
+				Optional:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"key":       schema.StringAttribute{Required: true},
+						"value":     schema.StringAttribute{Optional: true, Sensitive: true},
+						"generated": schema.BoolAttribute{Optional: true},
+					},
+				},
+			},
+			"image": schema.SingleNestedAttribute{
+				Description: "Service details for `image` type services.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"image_path":             schema.StringAttribute{Required: true},
+					"owner_id":               schema.StringAttribute{Required: true},
+					"registry_credential_id": schema.StringAttribute{Optional: true},
+				},
+			},
 
 			"web_service_details": schema.SingleNestedAttribute{
 				Description: "Service details for `web_service` type services.",
@@ -96,7 +125,8 @@ func (r *serviceResource) Schema(_ context.Context, req resource.SchemaRequest, 
 							"start_command": schema.StringAttribute{Optional: true},
 						},
 					},
-					"disk": disk,
+					"disk":   disk,
+					"docker": docker,
 				},
 			},
 

--- a/render/resources/service_environment.go
+++ b/render/resources/service_environment.go
@@ -270,11 +270,11 @@ func (r *serviceEnvironmentResource) Delete(ctx context.Context, req resource.De
 	response, err := r.client.UpdateEnvVarsForServiceWithResponse(ctx, state.Service.ValueString(), variables)
 
 	if err != nil {
-		resp.Diagnostics.AddError("failed to update service variables", err.Error())
+		resp.Diagnostics.AddError("failed to update service variables1", err.Error())
 		return
 	}
 
-	if response.StatusCode() != http.StatusCreated {
+	if response.StatusCode() != http.StatusOK {
 		resp.Diagnostics.AddError("failed to update service variables", string(response.Body))
 		return
 	}


### PR DESCRIPTION
- Added support for persistent disk in the WebServiceDetails as it is supported by Render API
- Added an example service with disk support in README.md
- Fixed a typo in the flask example's env type


![image](https://github.com/jackall3n/terraform-provider-render/assets/1157440/4024fcc9-e13b-4f74-936d-df7d4063b95b)
